### PR TITLE
Bump minor version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-image-modal",
   "title": "Image Modal XBlock",
   "description": "A fullscreen image modal XBlock.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/Stanford-Online/xblock-image-modal",
   "author": {
     "name": "stv",


### PR DESCRIPTION
This adds a new, backward-compatible feature:
- customizable alt text for screenreaders

Previously, the alt text was always set to the display name.
While this is still the default, instructors can now edit the value
manually.