### PR TITLE
Bump PATCH version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-image-modal",
   "title": "Image Modal XBlock",
   "description": "A fullscreen image modal XBlock.",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/Stanford-Online/xblock-image-modal",
   "author": {
     "name": "stv",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-image-modal",
   "title": "Image Modal XBlock",
   "description": "A fullscreen image modal XBlock.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/Stanford-Online/xblock-image-modal",
   "author": {
     "name": "stv",


### PR DESCRIPTION
This fixes the problem of the `previous` and `next` buttons appearing
over the full-screen version of the image modal.

Now, the full-screen image appears over these navigation buttons, which
are no longer visible in full-screen mode.