### PR TITLE
Translate class members lazily

### DIFF
--- a/imagemodal/imagemodal.py
+++ b/imagemodal/imagemodal.py
@@ -5,7 +5,7 @@ import os
 
 import pkg_resources
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from xblock.core import XBlock
 from xblock.fields import Scope

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-image-modal",
   "title": "Image Modal XBlock",
   "description": "A fullscreen image modal XBlock.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/Stanford-Online/xblock-image-modal",
   "author": {
     "name": "stv",


### PR DESCRIPTION
Since these lines are actually evaluated at build/startup time, we need
to defer the translation until runtime.

Otherwise, later versions of Django throw a fit:

> AppRegistryNotReady: The translation infrastructure cannot be
> initialized before the apps registry is ready. Check that you don't
> make non-lazy gettext calls at import time.