### PR TITLE
Stop translating default display name

### DIFF
--- a/imagemodal/imagemodal.py
+++ b/imagemodal/imagemodal.py
@@ -45,7 +45,7 @@ class ImageModal(StudioEditableXBlockMixin, XBlock):
 
     display_name = String(
         display_name=_('Display Name'),
-        default=_('Image Modal XBlock'),
+        default='Image Modal XBlock',
         scope=Scope.settings,
         help=_("This is the XBlock's display name"),
     )

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-image-modal",
   "title": "Image Modal XBlock",
   "description": "A fullscreen image modal XBlock.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "homepage": "https://github.com/Stanford-Online/xblock-image-modal",
   "author": {
     "name": "stv",


### PR DESCRIPTION
to avoid issues w/ lazy translation.

It looks like the two affected XBlocks are image-modal and qualtrics [1][2].

- [1] https://github.com/Stanford-Online/edx-platform/commit/a35c553ced25241f5f26ca2bd9093695f455ba63
- [2] https://github.com/Stanford-Online/xblock-qualtrics-survey/pull/10