### PR TITLE
Added the flag for showing the xblock in read only mode, which makes …

### DIFF
--- a/imagemodal/imagemodal.py
+++ b/imagemodal/imagemodal.py
@@ -31,6 +31,8 @@ class ImageModal(
 
     loader = ResourceLoader(__name__)
 
+    show_in_read_only_mode = True
+
     display_name = String(
         display_name=_('Display Name'),
         default='Image Modal XBlock',


### PR DESCRIPTION
Add flag for showing the xblock in read only mode

Make the image modal xblock visible for specified students.

Test locally on studio and lms, through adding the xblock to a course
and toggling view between staff and specified student.

@stvstnfrd @caesar2164 