### PR TITLE
Internationalize XBlock

### DIFF
--- a/imagemodal/settings.py
+++ b/imagemodal/settings.py
@@ -8,9 +8,10 @@ DATABASES = {
         # 'NAME': 'intentionally-omitted',
     },
 }
-
 INSTALLED_APPS = (
     'imagemodal',
 )
-
+LOCALE_PATHS = [
+    'imagemodal/translations',
+]
 SECRET_KEY = 'SECRET_KEY'

--- a/imagemodal/translations/en/LC_MESSAGES/django.po
+++ b/imagemodal/translations/en/LC_MESSAGES/django.po
@@ -1,0 +1,62 @@
+# Stanford's Image Modal XBlock.
+# Copyright (C) 2019
+# This file is distributed under the same license as the package.
+# Steven Burch <stv@stanford.edu>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-09 18:45-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Steven Burch <stv@stanford.edu>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: imagemodal/imagemodal.py:35
+msgid "Display Name"
+msgstr ""
+
+#: imagemodal/imagemodal.py:38
+msgid "This is the XBlock's display name"
+msgstr ""
+
+#: imagemodal/imagemodal.py:42
+msgid "Image URL"
+msgstr ""
+
+#: imagemodal/imagemodal.py:51
+msgid "This is the location of the full-screen image to be displayed."
+msgstr ""
+
+#: imagemodal/imagemodal.py:56
+msgid "Thumbnail URL"
+msgstr ""
+
+#: imagemodal/imagemodal.py:60
+msgid ""
+"This is the (optional) location of a thumbnail image to be displayed before "
+"the main image has been enlarged."
+msgstr ""
+
+#: imagemodal/imagemodal.py:66
+msgid "Description"
+msgstr ""
+
+#: imagemodal/imagemodal.py:69
+msgid "Description text, displayed to screen readers"
+msgstr ""
+
+#: imagemodal/imagemodal.py:74
+msgid "Alt Text"
+msgstr ""
+
+#: imagemodal/imagemodal.py:78
+msgid ""
+"This field allows you to add alternate or descriptive textthat pertains to "
+"your image."
+msgstr ""


### PR DESCRIPTION
Note: A few notable XBlocks in the wild (ora2, free-text-response) place
their translations in `{package}/locale`, which is then symlinked to at
`conf/locale`. Despite this, I'm following this documation from edx [1],
and placing them in `{package}/translations`:

> Create a directory within your XBlock code project named “translations”. This directory should be located at the same level in your code project as your XBlock implementation file. For example:
>  - http://github.com/my_org/my_xblock/my_xblock/my_xblock.py
>  - http://github.com/my_org/my_xblock/my_xblock/translations/

Localization and Transifex integration to follow in an upcoming PR.

[1] https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html#adding-translated-strings-to-your-xblock
