### PR TITLE
Copy translations during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 from setuptools import setup
 
 
-version = '1.0.0'
+version = '1.0.1'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
             'public/*',
             'scenarios/*.xml',
             'templates/*',
+            'translations/*/*/*',
         ],
     },
     classifiers=[


### PR DESCRIPTION
# Overview
We weren't including these files when installing via PyPi.
Now we are :)

# Test Instructions
- Checkout the branch
- Make sure nothing seems broken :)
- Ensure the translations files get bundled during distribution:
    ```sh
    python setup.py sdist >/dev/null && \
    tar tf dist/xblock-image-modal-1.0.1.tar.gz | grep translations
    ```

# TODO
- [x] Bump the version number in `setup.py`
- [x] Code Reviewer 1: @kluo  
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
